### PR TITLE
Fix retry attempts

### DIFF
--- a/lib/r4r/retry.rb
+++ b/lib/r4r/retry.rb
@@ -51,7 +51,6 @@ module R4r
       @budget.deposit
 
       while num_retry <= @backoff.size
-
         begin
           return yield(num_retry)
         rescue => err
@@ -80,10 +79,10 @@ module R4r
               cause: err
             )
           end
-        end
 
-        sleep @backoff[num_retry]
-        num_retry += 1
+          sleep @backoff[num_retry]
+          num_retry += 1
+        end
       end
     end
 

--- a/lib/r4r/version.rb
+++ b/lib/r4r/version.rb
@@ -1,3 +1,3 @@
 module R4r
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
`Retry` class does not respect count of elements in backoff parameter which leads to continuous retries.